### PR TITLE
apply customAuthFilter to product service, order service

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@
 - MSA Archiecture
 ![아키텍쳐 drawio](https://user-images.githubusercontent.com/43127088/148683531-e2f8c96e-2b63-47d1-b5e3-06d03bb4feaf.png)
 
+1. user에서 회원가입을 진행합니다.
+2. 한번 로그인 하면 여러 도메인에서 더 이상의 로그인 없이 이용할 수 있도록 SAML의 sso 방식처럼, auth 를 따로 두어 그 곳에서 인증을 하고, 인증에 성공하면 로그인을 진핼합니다.
+3. 로그인에 성공하면, api gateway에서 토큰을 받아 사용자 정보를 추출하여 header에 삽입합니다.
+4. api gateway에서 만들어진 토큰을 이용해서 product, order의 인가 작업을 진행하고 신뢰할 수 있는 토큰이면 인가에 성공합니다.
+5. 인가에 성공하면, api gateway header에 있는 사용자 정보를 가져와 상품 생성 및 주문 등을 수행합니다.
+6. 카프카의 토픽과 메세지 큐를 이용해 non-blocking 방식으로 product와 order간에 주문 작업을 진행합니다.  
+
+- 모든 작업은 api gateway를 통해 이루어 집니다.
+- 각각의 서버 모두 독립된 서비스로 나누었기 떄문에, 각 서비스는 독립된 배포 및 분산되고, 자율적으로 개발되고, 크기가 작고, 기능 중심적이고, 자동화된 프로세스로 구축되고 배포됩니다. 
+- 또한 각각의 MicroService에서 발생하는 장애가 전체 시스템 장애로 확장되지 않습니다.
 
 - DDD -> Hexagonal Architecture(육각형 아키텍쳐) 적용
 ![Hexagonal-Simplified](https://user-images.githubusercontent.com/43127088/148683425-420094f0-b965-4571-b3e3-44513111bcef.png)

--- a/gateway/src/main/kotlin/me/hyungil/gateway/filter/CustomAuthFilter.kt
+++ b/gateway/src/main/kotlin/me/hyungil/gateway/filter/CustomAuthFilter.kt
@@ -7,15 +7,17 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.cloud.gateway.filter.GatewayFilter
 import org.springframework.cloud.gateway.filter.GatewayFilterChain
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
-import org.springframework.http.server.reactive.ServerHttpRequest
 import org.springframework.http.server.reactive.ServerHttpResponse
 import org.springframework.stereotype.Component
 import org.springframework.web.server.ServerWebExchange
 import reactor.core.publisher.Mono
 import java.nio.charset.StandardCharsets
-import java.util.*
+import java.util.Objects
+import java.util.function.Consumer
 import javax.annotation.PostConstruct
+
 
 @Component
 class CustomAuthFilter(
@@ -26,7 +28,6 @@ class CustomAuthFilter(
 ) : AbstractGatewayFilterFactory<CustomAuthFilter.Config>(Config::class.java) {
 
     companion object {
-        const val TOKEN = "token"
         const val BEARER = "Bearer"
         const val EMAIL = "email"
     }
@@ -40,25 +41,29 @@ class CustomAuthFilter(
 
         return (GatewayFilter { exchange: ServerWebExchange, chain: GatewayFilterChain ->
 
-            val request: ServerHttpRequest = exchange.request
-            val response: ServerHttpResponse = exchange.response
+            val request = exchange.request
 
-            if ((!request.headers.containsKey(TOKEN))) {
+            if ((!request.headers.containsKey(HttpHeaders.AUTHORIZATION))) {
                 return@GatewayFilter handleUnAuthorized(exchange)
             }
 
-            val token: List<String> = request.headers[TOKEN] as List<String>
-            val tokenString: String = Objects.requireNonNull(token)[0]
+            val token = request.headers[HttpHeaders.AUTHORIZATION] as List<String>
+            val tokenString = Objects.requireNonNull(token)[0]
 
             if (!tokenString.startsWith(BEARER)) {
                 return@GatewayFilter handleUnAuthorized(exchange)
             }
 
-            val claims: Claims = getClaims(tokenString.substring("$BEARER ".length))
+            val claims = getClaims(tokenString.substring("$BEARER ".length))
 
-            response.headers.set(EMAIL, claims[EMAIL].toString())
+            val httpHeaders =
+                Consumer<HttpHeaders> { httpHeader -> httpHeader.set(EMAIL, claims[EMAIL].toString()) }
 
-            chain.filter(exchange)
+            val serverHttpRequest = exchange.request.mutate().headers(httpHeaders).build()
+
+            exchange.mutate().request(serverHttpRequest).build()
+
+            return@GatewayFilter chain.filter(exchange.mutate().request(request).build())
 
         })
     }
@@ -72,9 +77,7 @@ class CustomAuthFilter(
         return response.setComplete()
     }
 
-    private fun getClaims(token: String): Claims {
-        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).body
-    }
+    private fun getClaims(token: String) = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).body
 
     class Config
 }

--- a/gateway/src/main/resources/application-local.yml
+++ b/gateway/src/main/resources/application-local.yml
@@ -7,25 +7,41 @@ spring:
   cloud:
     gateway:
       routes:
+
+        - id: commerce-auth
+          uri: ${AUTH_DEFAULT_URL}
+          predicates:
+            - Path=/v1/auth/**
+
         - id: commerce-user
           uri: ${USER_DEFAULT_URL}
           predicates:
             - Path=/v1/users/**
           filters:
             - CustomAuthFilter
-        - id: commerce-auth
-          uri: ${AUTH_DEFAULT_URL}
-          predicates:
-            - Path=/v1/auth/**
+            - RewritePath=/v1/products/(?<path>.*),/$\{path}
+
         - id: commerce-product
           uri: ${PRODUCT_DEFAULT_URL}
           predicates:
             - Path=/v1/products/**
           filters:
-            - RemoveRequestHeader=Cookie
+            - CustomAuthFilter
+            - RewritePath=/v1/products/(?<path>.*),/$\{path}
+
         - id: commerce-order
           uri: ${ORDER_DEFAULT_URL}
           predicates:
             - Path=/v1/orders/**
           filters:
-            - RemoveRequestHeader=Cookie
+            - CustomAuthFilter
+            - RewritePath=/v1/products/(?<path>.*),/$\{path}
+
+eureka:
+  client:
+    fetch-registry: true
+    register-with-eureka: true
+    service-url:
+      defaultZone: ${EUREKA_URL}
+  instance:
+    hostname: ${EUREKA_HOST}

--- a/order/src/main/kotlin/me/hyungil/order/adapter/in/presentation/v1/OrderApi.kt
+++ b/order/src/main/kotlin/me/hyungil/order/adapter/in/presentation/v1/OrderApi.kt
@@ -14,6 +14,6 @@ class OrderApi(
 
     @PostMapping("{userId}")
     @ResponseStatus(HttpStatus.CREATED)
-    fun createOrder(@PathVariable userId: Long, @RequestBody orderRequest: OrderRequest) =
-        GetOrderResponse(orderUseCase.createOrder(userId, orderRequest))
+    fun createOrder(@PathVariable userId: Long, @RequestBody orderRequest: OrderRequest, @RequestHeader("email") email: String) =
+        GetOrderResponse(orderUseCase.createOrder(userId, orderRequest, email))
 }

--- a/order/src/main/kotlin/me/hyungil/order/adapter/out/infrastructure/persist/OrderEntity.kt
+++ b/order/src/main/kotlin/me/hyungil/order/adapter/out/infrastructure/persist/OrderEntity.kt
@@ -16,6 +16,9 @@ class OrderEntity(
     val productId: String,
 
     @Column(nullable = false)
+    val email: String,
+
+    @Column(nullable = false)
     val quantity: Long,
 
     @Column(nullable = false)
@@ -35,6 +38,7 @@ class OrderEntity(
     constructor(order: Order) : this(
         id = order.id,
         productId = order.productId,
+        email = order.email,
         quantity = order.quantity,
         unitPrice = order.unitPrice,
         totalPrice = order.quantity * order.unitPrice,
@@ -42,5 +46,14 @@ class OrderEntity(
         orderId = order.orderId
     )
 
-    fun toOrderDomain() = Order(id, productId, quantity, unitPrice, totalPrice, userId, orderId)
+    fun toOrderDomain() = Order(
+        id = id,
+        email = email,
+        productId = productId,
+        quantity = quantity,
+        unitPrice = unitPrice,
+        totalPrice = totalPrice,
+        userId = userId,
+        orderId = orderId
+    )
 }

--- a/order/src/main/kotlin/me/hyungil/order/application/order/port/in/GetOrderResponse.kt
+++ b/order/src/main/kotlin/me/hyungil/order/application/order/port/in/GetOrderResponse.kt
@@ -4,6 +4,8 @@ import me.hyungil.order.domain.order.Order
 
 data class GetOrderResponse(
 
+    val email: String,
+
     val productId: String,
 
     val quantity: Long,
@@ -16,6 +18,7 @@ data class GetOrderResponse(
 ) {
 
     constructor(order: Order) : this(
+        email = order.email,
         productId = order.productId,
         quantity = order.quantity,
         unitPrice = order.unitPrice,

--- a/order/src/main/kotlin/me/hyungil/order/application/order/port/in/OrderRequest.kt
+++ b/order/src/main/kotlin/me/hyungil/order/application/order/port/in/OrderRequest.kt
@@ -13,8 +13,9 @@ data class OrderRequest(
     val unitPrice: Long
 ) {
 
-    fun toOrderDomain(userId: Long) =
+    fun toOrderDomain(userId: Long, email: String) =
         Order(
+            email = email,
             productId = productId,
             quantity = quantity,
             unitPrice = unitPrice,

--- a/order/src/main/kotlin/me/hyungil/order/application/order/port/in/OrderUseCase.kt
+++ b/order/src/main/kotlin/me/hyungil/order/application/order/port/in/OrderUseCase.kt
@@ -4,5 +4,5 @@ import me.hyungil.order.domain.order.Order
 
 interface OrderUseCase {
 
-    fun createOrder(userId: Long, orderRequest: OrderRequest): Order
+    fun createOrder(userId: Long, orderRequest: OrderRequest, email: String): Order
 }

--- a/order/src/main/kotlin/me/hyungil/order/application/order/service/OrderService.kt
+++ b/order/src/main/kotlin/me/hyungil/order/application/order/service/OrderService.kt
@@ -12,10 +12,10 @@ class OrderService(
     private val kafkaProducer: KafkaProducer
 ) : OrderUseCase {
 
-    override fun createOrder(userId: Long, orderRequest: OrderRequest): Order {
+    override fun createOrder(userId: Long, orderRequest: OrderRequest, email: String): Order {
 
         kafkaProducer.send("order-product-topic", orderRequest)
 
-        return orderAdapter.save(orderRequest.toOrderDomain(userId))
+        return orderAdapter.save(orderRequest.toOrderDomain(userId, email))
     }
 }

--- a/order/src/main/kotlin/me/hyungil/order/domain/order/Order.kt
+++ b/order/src/main/kotlin/me/hyungil/order/domain/order/Order.kt
@@ -6,6 +6,8 @@ class Order(
 
     val id: Long = 0,
 
+    val email: String,
+
     val productId: String,
 
     val quantity: Long,

--- a/order/src/main/resources/db/migration/V2__add_email_column_in_order.sql
+++ b/order/src/main/resources/db/migration/V2__add_email_column_in_order.sql
@@ -1,0 +1,1 @@
+ALTER TABLE order_item ADD email VARCHAR(45) NOT NULL;

--- a/product/src/main/kotlin/me/hyungil/product/adapter/in/presentation/v1/ProductApi.kt
+++ b/product/src/main/kotlin/me/hyungil/product/adapter/in/presentation/v1/ProductApi.kt
@@ -3,9 +3,17 @@ package me.hyungil.product.adapter.`in`.presentation.v1
 import me.hyungil.product.application.product.port.`in`.GetProductResponse
 import me.hyungil.product.application.product.port.`in`.ProductRequest
 import me.hyungil.product.application.product.port.`in`.ProductUseCase
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.http.server.reactive.ServerHttpResponse
 import org.springframework.web.bind.annotation.*
+import org.springframework.web.server.ServerWebExchange
+import javax.servlet.http.HttpServlet
+import javax.servlet.http.HttpServletRequest
 import javax.validation.Valid
+
 
 @RestController
 @RequestMapping("v1/products")
@@ -15,8 +23,11 @@ class ProductApi(
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    fun createProduct(@Valid @RequestBody productRequest: ProductRequest) =
-        GetProductResponse(productUseCase.createProduct(productRequest))
+    fun createProduct(
+        @Valid @RequestBody productRequest: ProductRequest,
+        @RequestHeader("email") email: String
+    ): GetProductResponse = GetProductResponse(productUseCase.createProduct(productRequest, email))
+
 
     @GetMapping
     fun getProducts() = productUseCase.getProducts().map { GetProductResponse(it) }

--- a/product/src/main/kotlin/me/hyungil/product/adapter/out/infrastructure/persistence/ProductEntity.kt
+++ b/product/src/main/kotlin/me/hyungil/product/adapter/out/infrastructure/persistence/ProductEntity.kt
@@ -16,6 +16,9 @@ class ProductEntity(
     val productId: String,
 
     @Column(nullable = false)
+    val email: String,
+
+    @Column(nullable = false)
     val productName: String,
 
     @Column(nullable = false)
@@ -29,10 +32,11 @@ class ProductEntity(
     constructor(product: Product) : this(
         product.id,
         product.productId,
+        product.email,
         product.productName,
         product.unitPrice,
         product.stock,
     )
 
-    fun toProductDomain() = Product(id, productId, productName, unitPrice, stock, createdAt, updatedAt)
+    fun toProductDomain() = Product(id, productId, email, productName, unitPrice, stock, createdAt, updatedAt)
 }

--- a/product/src/main/kotlin/me/hyungil/product/application/product/port/in/GetProductResponse.kt
+++ b/product/src/main/kotlin/me/hyungil/product/application/product/port/in/GetProductResponse.kt
@@ -8,6 +8,8 @@ data class GetProductResponse(
 
     val productId: String,
 
+    val email: String,
+
     val productName: String,
 
     val unitPrice: Long,
@@ -22,6 +24,7 @@ data class GetProductResponse(
     constructor(product: Product) : this(
         id = product.id,
         productId = product.productId,
+        email = product.email,
         productName = product.productName,
         unitPrice = product.unitPrice,
         stock = product.stock,

--- a/product/src/main/kotlin/me/hyungil/product/application/product/port/in/ProductRequest.kt
+++ b/product/src/main/kotlin/me/hyungil/product/application/product/port/in/ProductRequest.kt
@@ -16,6 +16,6 @@ data class ProductRequest(
     val stock: Long
 ) {
 
-    fun toProductDomain() =
-        Product(productId = productId, productName = productName, unitPrice = unitPrice, stock = stock)
+    fun toProductDomain(email: String) =
+        Product(productId = productId, email = email, productName = productName, unitPrice = unitPrice, stock = stock)
 }

--- a/product/src/main/kotlin/me/hyungil/product/application/product/port/in/ProductUseCase.kt
+++ b/product/src/main/kotlin/me/hyungil/product/application/product/port/in/ProductUseCase.kt
@@ -4,7 +4,7 @@ import me.hyungil.product.domain.product.Product
 
 interface ProductUseCase {
 
-    fun createProduct(productRequest: ProductRequest): Product
+    fun createProduct(productRequest: ProductRequest, email: String): Product
 
     fun getProducts(): List<Product>
 }

--- a/product/src/main/kotlin/me/hyungil/product/application/product/service/ProductService.kt
+++ b/product/src/main/kotlin/me/hyungil/product/application/product/service/ProductService.kt
@@ -8,7 +8,8 @@ import org.springframework.stereotype.Service
 @Service
 class ProductService(private val productAdapter: ProductPort) : ProductUseCase {
 
-    override fun createProduct(productRequest: ProductRequest) = productAdapter.save(productRequest.toProductDomain())
+    override fun createProduct(productRequest: ProductRequest, email: String) =
+        productAdapter.save(productRequest.toProductDomain(email))
 
     override fun getProducts() = productAdapter.findAll()
 }

--- a/product/src/main/kotlin/me/hyungil/product/domain/product/Product.kt
+++ b/product/src/main/kotlin/me/hyungil/product/domain/product/Product.kt
@@ -8,6 +8,8 @@ class Product(
 
     val productId: String,
 
+    val email: String,
+
     val productName: String,
 
     val unitPrice: Long,

--- a/product/src/main/resources/db/migration/V2__add_email_column_in_product.sql
+++ b/product/src/main/resources/db/migration/V2__add_email_column_in_product.sql
@@ -1,0 +1,1 @@
+ALTER TABLE product ADD email VARCHAR(25) NOT NULL;


### PR DESCRIPTION
이전 feature에서는 auth service에서 생성된 토큰을 api gateway에서 받아 온 후에, 다른 microService에 인가 작업을 수행하는 기능을 구현하였습니다. 그리고 이번 feature에서는 

product, order service에서 사용자 정보가 필요할 때마다 auth service나 user service에 불필요하게 접근하지 않게 하기 위해서
- api gateway에서 토큰에 들어있는 사용자 정보를 파싱해서 header에 추가하였습니다.
- 그리고, product, order service의 request를 proxy 하고 있는 api gateway의 header를 통해 간단하게 사용자 정보를 받아오도록 

customAuthFilter를 수정하고 product, order service에 customAuthFilter를 적용하였습니다.